### PR TITLE
If not all of the information exists for a specific episode/movie at least display what we have

### DIFF
--- a/EmberMediaManager/frmMain.vb
+++ b/EmberMediaManager/frmMain.vb
@@ -7894,6 +7894,7 @@ doCancel:
                 Me.ClearInfo()
                 Me.ShowNoInfo(True, 0)
                 Master.currMovie = Master.DB.LoadMovieFromDB(Convert.ToInt64(Me.dgvMediaList.Item(0, iRow).Value))
+                Me.fillScreenInfoWithMovie()
 
                 If Not Me.bwMovieScraper.IsBusy AndAlso Not Me.bwNonScrape.IsBusy AndAlso Not Me.fScanner.IsBusy AndAlso Not Me.bwMediaInfo.IsBusy AndAlso Not Me.bwLoadInfo.IsBusy AndAlso Not Me.bwLoadShowInfo.IsBusy AndAlso Not Me.bwLoadSeasonInfo.IsBusy AndAlso Not Me.bwLoadEpInfo.IsBusy AndAlso Not Me.bwRefreshMovies.IsBusy AndAlso Not Me.bwCleanDB.IsBusy Then
                     Me.mnuMediaList.Enabled = True


### PR DESCRIPTION
This tiny fix allows the path to the media file to be displayed in the Episode/Movie portion of the UI. (or whatever other information we currently have). Even if it isn't enough to call LoadEpisodeInfo or its movie equivalent.
