### PR TITLE
Prevent Null-deref if no image is selected during a movie scrape.

### DIFF
--- a/EmberMediaManager/frmMain.vb
+++ b/EmberMediaManager/frmMain.vb
@@ -1358,10 +1358,10 @@ Public Class frmMain
                                 End If
                                 Using dImgSelect As New dlgImgSelect()
                                     Fanart = dImgSelect.ShowDialog(DBScrapeMovie, Enums.ImageType.Fanart, aList)
-                                    If IsNothing(Fanart.WebImage.Image) Then
+                                    If Not IsNothing(Fanart) AndAlso IsNothing(Fanart.WebImage.Image) Then
                                         Fanart.WebImage.FromWeb(Fanart.URL)
                                     End If
-                                    If Not IsNothing(Fanart.WebImage.Image) Then
+                                    If Not IsNothing(Fanart) AndAlso Not IsNothing(Fanart.WebImage.Image) Then
                                         tURL = Fanart.WebImage.SaveAsFanart(DBScrapeMovie)
                                         If Not String.IsNullOrEmpty(tURL) Then
                                             DBScrapeMovie.FanartPath = tURL


### PR DESCRIPTION
This is likely to happen if no fanart scrapers are enabled.
