### PR TITLE
Return DialogResult from yet another dialog. dlgImgManual this time. Aga...

### DIFF
--- a/EmberMediaManager/dlgEditEpisode.vb
+++ b/EmberMediaManager/dlgEditEpisode.vb
@@ -651,16 +651,19 @@ Public Class dlgEditEpisode
     Private Sub btnSetPosterDL_Click(ByVal sender As System.Object, ByVal e As System.EventArgs) Handles btnSetPosterDL.Click
         Try
             Using dImgManual As New dlgImgManual
-				Dim tImage As Images = dImgManual.ShowDialog(Enums.ImageType.Posters)
-                If Not IsNothing(tImage.Image) Then
-                    Poster = tImage
-                    Me.pbPoster.Image = Poster.Image
-                    Me.pbPoster.Tag = Poster
+                Dim tImage As Images
+                If dImgManual.ShowDialog(Enums.ImageType.Posters) = DialogResult.OK Then
+                    tImage = dImgManual.Results
+                    If Not IsNothing(tImage.Image) Then
+                        Poster = tImage
+                        Me.pbPoster.Image = Poster.Image
+                        Me.pbPoster.Tag = Poster
 
-                    Me.lblPosterSize.Text = String.Format(Master.eLang.GetString(269, "Size: {0}x{1}"), Me.pbPoster.Image.Width, Me.pbPoster.Image.Height)
-                    Me.lblPosterSize.Visible = True
+                        Me.lblPosterSize.Text = String.Format(Master.eLang.GetString(269, "Size: {0}x{1}"), Me.pbPoster.Image.Width, Me.pbPoster.Image.Height)
+                        Me.lblPosterSize.Visible = True
+                    End If
                 End If
-			End Using
+            End Using
         Catch ex As Exception
             Master.eLog.WriteToErrorLog(ex.Message, ex.StackTrace, "Error")
         End Try
@@ -692,16 +695,19 @@ Public Class dlgEditEpisode
     Private Sub btnSetFanartDL_Click(ByVal sender As System.Object, ByVal e As System.EventArgs) Handles btnSetFanartDL.Click
         Try
 			Using dImgManual As New dlgImgManual
-				Dim tImage As Images = dImgManual.ShowDialog(Enums.ImageType.Fanart)
-                If Not IsNothing(tImage.Image) Then
-                    Fanart = tImage
-                    Me.pbFanart.Image = Fanart.Image
-                    Me.pbFanart.Tag = Fanart
+                Dim tImage As Images
+                If dImgManual.ShowDialog(Enums.ImageType.Fanart) = DialogResult.OK Then
+                    tImage = dImgManual.Results
+                    If Not IsNothing(tImage.Image) Then
+                        Fanart = tImage
+                        Me.pbFanart.Image = Fanart.Image
+                        Me.pbFanart.Tag = Fanart
 
-                    Me.lblFanartSize.Text = String.Format(Master.eLang.GetString(269, "Size: {0}x{1}"), Me.pbFanart.Image.Width, Me.pbFanart.Image.Height)
-                    Me.lblFanartSize.Visible = True
+                        Me.lblFanartSize.Text = String.Format(Master.eLang.GetString(269, "Size: {0}x{1}"), Me.pbFanart.Image.Width, Me.pbFanart.Image.Height)
+                        Me.lblFanartSize.Visible = True
+                    End If
                 End If
-			End Using
+            End Using
         Catch ex As Exception
             Master.eLog.WriteToErrorLog(ex.Message, ex.StackTrace, "Error")
         End Try

--- a/EmberMediaManager/dlgEditMovie.vb
+++ b/EmberMediaManager/dlgEditMovie.vb
@@ -205,14 +205,17 @@ Public Class dlgEditMovie
     Private Sub btnSetFanartDL_Click(ByVal sender As System.Object, ByVal e As System.EventArgs) Handles btnSetFanartDL.Click
         Try
             Using dImgManual As New dlgImgManual
-				Dim tImage As Images = dImgManual.ShowDialog(Enums.ImageType.Fanart)
-                If Not IsNothing(tImage.Image) Then
-                    Fanart = tImage
-                    Me.pbFanart.Image = Fanart.Image
-                    Me.pbFanart.Tag = Fanart
+                Dim tImage As Images
+                If dImgManual.ShowDialog(Enums.ImageType.Fanart) = DialogResult.OK Then
+                    tImage = dImgManual.Results
+                    If Not IsNothing(tImage.Image) Then
+                        Fanart = tImage
+                        Me.pbFanart.Image = Fanart.Image
+                        Me.pbFanart.Tag = Fanart
 
-                    Me.lblFanartSize.Text = String.Format(Master.eLang.GetString(269, "Size: {0}x{1}"), Me.pbFanart.Image.Width, Me.pbFanart.Image.Height)
-                    Me.lblFanartSize.Visible = True
+                        Me.lblFanartSize.Text = String.Format(Master.eLang.GetString(269, "Size: {0}x{1}"), Me.pbFanart.Image.Width, Me.pbFanart.Image.Height)
+                        Me.lblFanartSize.Visible = True
+                    End If
                 End If
             End Using
         Catch ex As Exception
@@ -270,14 +273,17 @@ Public Class dlgEditMovie
     Private Sub btnSetPosterDL_Click(ByVal sender As System.Object, ByVal e As System.EventArgs) Handles btnSetPosterDL.Click
         Try
             Using dImgManual As New dlgImgManual
-				Dim tImage As Images = dImgManual.ShowDialog(Enums.ImageType.Posters)
-                If Not IsNothing(tImage.Image) Then
-                    Poster = tImage
-                    Me.pbPoster.Image = Poster.Image
-                    Me.pbPoster.Tag = Poster
+                Dim tImage As Images
+                If dImgManual.ShowDialog(Enums.ImageType.Posters) = DialogResult.OK Then
+                    tImage = dImgManual.Results
+                    If Not IsNothing(tImage.Image) Then
+                        Poster = tImage
+                        Me.pbPoster.Image = Poster.Image
+                        Me.pbPoster.Tag = Poster
 
-                    Me.lblPosterSize.Text = String.Format(Master.eLang.GetString(269, "Size: {0}x{1}"), Me.pbPoster.Image.Width, Me.pbPoster.Image.Height)
-                    Me.lblPosterSize.Visible = True
+                        Me.lblPosterSize.Text = String.Format(Master.eLang.GetString(269, "Size: {0}x{1}"), Me.pbPoster.Image.Width, Me.pbPoster.Image.Height)
+                        Me.lblPosterSize.Visible = True
+                    End If
                 End If
             End Using
         Catch ex As Exception

--- a/EmberMediaManager/dlgEditSeason.vb
+++ b/EmberMediaManager/dlgEditSeason.vb
@@ -47,14 +47,17 @@ Public Class dlgEditSeason
     Private Sub btnSetFanartDL_Click(ByVal sender As System.Object, ByVal e As System.EventArgs) Handles btnSetFanartDL.Click
         Try
             Using dImgManual As New dlgImgManual
-				Dim tImage As Images = dImgManual.ShowDialog(Enums.ImageType.Fanart)
-                If Not IsNothing(tImage.Image) Then
-                    Fanart = tImage
-                    Me.pbFanart.Image = Fanart.Image
-                    Me.pbFanart.Tag = Fanart
+                Dim tImage As Images
+                If dImgManual.ShowDialog(Enums.ImageType.Fanart) = DialogResult.OK Then
+                    tImage = dImgManual.Results
+                    If Not IsNothing(tImage.Image) Then
+                        Fanart = tImage
+                        Me.pbFanart.Image = Fanart.Image
+                        Me.pbFanart.Tag = Fanart
 
-                    Me.lblFanartSize.Text = String.Format(Master.eLang.GetString(269, "Size: {0}x{1}"), Me.pbFanart.Image.Width, Me.pbFanart.Image.Height)
-                    Me.lblFanartSize.Visible = True
+                        Me.lblFanartSize.Text = String.Format(Master.eLang.GetString(269, "Size: {0}x{1}"), Me.pbFanart.Image.Width, Me.pbFanart.Image.Height)
+                        Me.lblFanartSize.Visible = True
+                    End If
                 End If
             End Using
         Catch ex As Exception
@@ -99,16 +102,19 @@ Public Class dlgEditSeason
     Private Sub btnSetPosterDL_Click(ByVal sender As System.Object, ByVal e As System.EventArgs) Handles btnSetPosterDL.Click
         Try
             Using dImgManual As New dlgImgManual
-				Dim tImage As Images = dImgManual.ShowDialog(Enums.ImageType.Posters)
-                If Not IsNothing(tImage.Image) Then
-                    Poster = tImage
-                    Me.pbPoster.Image = Poster.Image
-                    Me.pbPoster.Tag = Poster
+                Dim tImage As Images
+                If dImgManual.ShowDialog(Enums.ImageType.Posters) = DialogResult.OK Then
+                    tImage = dImgManual.Results
+                    If Not IsNothing(tImage.Image) Then
+                        Poster = tImage
+                        Me.pbPoster.Image = Poster.Image
+                        Me.pbPoster.Tag = Poster
 
-                    Me.lblPosterSize.Text = String.Format(Master.eLang.GetString(269, "Size: {0}x{1}"), Me.pbPoster.Image.Width, Me.pbPoster.Image.Height)
-                    Me.lblPosterSize.Visible = True
+                        Me.lblPosterSize.Text = String.Format(Master.eLang.GetString(269, "Size: {0}x{1}"), Me.pbPoster.Image.Width, Me.pbPoster.Image.Height)
+                        Me.lblPosterSize.Visible = True
+                    End If
                 End If
-			End Using
+            End Using
         Catch ex As Exception
             Master.eLog.WriteToErrorLog(ex.Message, ex.StackTrace, "Error")
         End Try

--- a/EmberMediaManager/dlgEditShow.vb
+++ b/EmberMediaManager/dlgEditShow.vb
@@ -111,16 +111,19 @@ Public Class dlgEditShow
     Private Sub btnASPosterChangeDL_Click(ByVal sender As System.Object, ByVal e As System.EventArgs) Handles btnASPosterChangeDL.Click
         Try
             Using dImgManual As New dlgImgManual
-				Dim tImage As Images = dImgManual.ShowDialog(Enums.ImageType.ASPoster)
-                If Not IsNothing(tImage.Image) Then
-                    ASPoster = tImage
-                    Me.pbASPoster.Image = ASPoster.Image
-                    Me.pbASPoster.Tag = ASPoster
+                Dim tImage As Images
+                If dImgManual.ShowDialog(Enums.ImageType.ASPoster) = DialogResult.OK Then
+                    tImage = dImgManual.Results
+                    If Not IsNothing(tImage.Image) Then
+                        ASPoster = tImage
+                        Me.pbASPoster.Image = ASPoster.Image
+                        Me.pbASPoster.Tag = ASPoster
 
-                    Me.lblASSize.Text = String.Format(Master.eLang.GetString(269, "Size: {0}x{1}"), Me.pbASPoster.Image.Width, Me.pbASPoster.Image.Height)
-                    Me.lblASSize.Visible = True
+                        Me.lblASSize.Text = String.Format(Master.eLang.GetString(269, "Size: {0}x{1}"), Me.pbASPoster.Image.Width, Me.pbASPoster.Image.Height)
+                        Me.lblASSize.Visible = True
+                    End If
                 End If
-			End Using
+            End Using
         Catch ex As Exception
             Master.eLog.WriteToErrorLog(ex.Message, ex.StackTrace, "Error")
         End Try
@@ -166,16 +169,19 @@ Public Class dlgEditShow
     Private Sub btnSetFanartDL_Click(ByVal sender As System.Object, ByVal e As System.EventArgs) Handles btnSetFanartDL.Click
         Try
             Using dImgManual As New dlgImgManual
-				Dim tImage As Images = dImgManual.ShowDialog(Enums.ImageType.Fanart)
-                If Not IsNothing(tImage.Image) Then
-                    Fanart = tImage
-                    Me.pbFanart.Image = Fanart.Image
-                    Me.pbFanart.Tag = Fanart
+                Dim tImage As Images
+                If dImgManual.ShowDialog(Enums.ImageType.Fanart) = DialogResult.OK Then
+                    tImage = dImgManual.Results
+                    If Not IsNothing(tImage.Image) Then
+                        Fanart = tImage
+                        Me.pbFanart.Image = Fanart.Image
+                        Me.pbFanart.Tag = Fanart
 
-                    Me.lblFanartSize.Text = String.Format(Master.eLang.GetString(269, "Size: {0}x{1}"), Me.pbFanart.Image.Width, Me.pbFanart.Image.Height)
-                    Me.lblFanartSize.Visible = True
+                        Me.lblFanartSize.Text = String.Format(Master.eLang.GetString(269, "Size: {0}x{1}"), Me.pbFanart.Image.Width, Me.pbFanart.Image.Height)
+                        Me.lblFanartSize.Visible = True
+                    End If
                 End If
-			End Using
+            End Using
         Catch ex As Exception
             Master.eLog.WriteToErrorLog(ex.Message, ex.StackTrace, "Error")
         End Try
@@ -220,16 +226,19 @@ Public Class dlgEditShow
     Private Sub btnSetPosterDL_Click(ByVal sender As System.Object, ByVal e As System.EventArgs) Handles btnSetPosterDL.Click
         Try
             Using dImgManual As New dlgImgManual
-				Dim tImage As Images = dImgManual.ShowDialog(Enums.ImageType.Posters)
-                If Not IsNothing(tImage.Image) Then
-                    Poster = tImage
-                    Me.pbPoster.Image = Poster.Image
-                    Me.pbPoster.Tag = Poster
+                Dim tImage As Images
+                If dImgManual.ShowDialog(Enums.ImageType.Posters) = DialogResult.OK Then
+                    tImage = dImgManual.Results
+                    If Not IsNothing(tImage.Image) Then
+                        Poster = tImage
+                        Me.pbPoster.Image = Poster.Image
+                        Me.pbPoster.Tag = Poster
 
-                    Me.lblPosterSize.Text = String.Format(Master.eLang.GetString(269, "Size: {0}x{1}"), Me.pbPoster.Image.Width, Me.pbPoster.Image.Height)
-                    Me.lblPosterSize.Visible = True
+                        Me.lblPosterSize.Text = String.Format(Master.eLang.GetString(269, "Size: {0}x{1}"), Me.pbPoster.Image.Width, Me.pbPoster.Image.Height)
+                        Me.lblPosterSize.Visible = True
+                    End If
                 End If
-			End Using
+            End Using
         Catch ex As Exception
             Master.eLog.WriteToErrorLog(ex.Message, ex.StackTrace, "Error")
         End Try

--- a/EmberMediaManager/dlgImgManual.vb
+++ b/EmberMediaManager/dlgImgManual.vb
@@ -31,21 +31,29 @@ Public Class dlgImgManual
 
 #End Region 'Fields
 
+#Region "Properties"
+
+    Public Property Results As Images
+        Get
+            Return tImage
+        End Get
+        Set(value As Images)
+            tImage = value
+        End Set
+    End Property
+
+#End Region
+
 #Region "Methods"
 
-	Public Overloads Function ShowDialog(ByVal _DLType As Enums.ImageType) As Images
-		'//
-		' Overload to pass data and return image
-		'\\
+    Public Overloads Function ShowDialog(ByVal _DLType As Enums.ImageType) As DialogResult
+        '//
+        ' Overload to pass data
+        '\\
 
-		Me.DLType = _DLType
-
-		If MyBase.ShowDialog() = Windows.Forms.DialogResult.OK Then
-			Return tImage
-		Else
-			Return Nothing
-		End If
-	End Function
+        Me.DLType = _DLType
+        Return MyBase.ShowDialog()
+    End Function
 
 	Private Sub btnPreview_Click(ByVal sender As System.Object, ByVal e As System.EventArgs) Handles btnPreview.Click
 		Try


### PR DESCRIPTION
...in, this is to prevent NULL-derefs when you cancel the dialog. All callers updated.

This was based on gates71 error log copy/paste from:

http://forum.xbmc.org/showthread.php?tid=168427
