### PR TITLE
Fix the bulk renamer dialog startup codepath by calling .Read() before t...

### DIFF
--- a/Addons/generic.EmberCore.BulkRename/dlgBulkRename.vb
+++ b/Addons/generic.EmberCore.BulkRename/dlgBulkRename.vb
@@ -87,7 +87,9 @@ Public Class dlgBulkRenamer
                 Dim iProg As Integer = 0
                 SQLNewcommand.CommandText = String.Concat("SELECT COUNT(id) AS mcount FROM movies;")
                 Using SQLcount As SQLite.SQLiteDataReader = SQLNewcommand.ExecuteReader()
-                    Me.bwLoadInfo.ReportProgress(-1, SQLcount("mcount")) ' set maximum
+                    If SQLcount.HasRows AndAlso SQLcount.Read() Then
+                        Me.bwLoadInfo.ReportProgress(-1, SQLcount("mcount")) ' set maximum
+                    End If
                 End Using
                 SQLNewcommand.CommandText = String.Concat("SELECT NfoPath ,id FROM movies ORDER BY ListTitle ASC;")
                 Using SQLreader As SQLite.SQLiteDataReader = SQLNewcommand.ExecuteReader()


### PR DESCRIPTION
...rying to access a column.

We must call .Read() before accessing a column's value.
