### PR TITLE
Correct the Link to Open BugTracker Issues in the Error Viewer

### DIFF
--- a/EmberMediaManager/dlgErrorViewer.Designer.vb
+++ b/EmberMediaManager/dlgErrorViewer.Designer.vb
@@ -22,113 +22,113 @@ Partial Class dlgErrorViewer
     'Do not modify it using the code editor.
     <System.Diagnostics.DebuggerStepThrough()> _
     Private Sub InitializeComponent()
-		Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(dlgErrorViewer))
-		Me.OK_Button = New System.Windows.Forms.Button()
-		Me.txtError = New System.Windows.Forms.TextBox()
-		Me.btnCopy = New System.Windows.Forms.Button()
-		Me.txtPastebinURL = New System.Windows.Forms.TextBox()
-		Me.lblPastebinURL = New System.Windows.Forms.Label()
-		Me.lblInfo = New System.Windows.Forms.Label()
-		Me.llblURL = New System.Windows.Forms.LinkLabel()
-		Me.SuspendLayout()
-		'
-		'OK_Button
-		'
-		Me.OK_Button.DialogResult = System.Windows.Forms.DialogResult.Cancel
-		Me.OK_Button.Location = New System.Drawing.Point(797, 381)
-		Me.OK_Button.Name = "OK_Button"
-		Me.OK_Button.Size = New System.Drawing.Size(67, 23)
-		Me.OK_Button.TabIndex = 0
-		Me.OK_Button.Text = "OK"
-		'
-		'txtError
-		'
-		Me.txtError.BackColor = System.Drawing.Color.White
-		Me.txtError.Location = New System.Drawing.Point(6, 7)
-		Me.txtError.Multiline = True
-		Me.txtError.Name = "txtError"
-		Me.txtError.ReadOnly = True
-		Me.txtError.ScrollBars = System.Windows.Forms.ScrollBars.Vertical
-		Me.txtError.Size = New System.Drawing.Size(858, 331)
-		Me.txtError.TabIndex = 1
-		'
-		'btnCopy
-		'
-		Me.btnCopy.Location = New System.Drawing.Point(6, 381)
-		Me.btnCopy.Name = "btnCopy"
-		Me.btnCopy.Size = New System.Drawing.Size(150, 23)
-		Me.btnCopy.TabIndex = 2
-		Me.btnCopy.Text = "Copy To Clipboard"
-		Me.btnCopy.UseVisualStyleBackColor = True
-		Me.btnCopy.Visible = False
-		'
-		'txtPastebinURL
-		'
-		Me.txtPastebinURL.BackColor = System.Drawing.Color.White
-		Me.txtPastebinURL.Location = New System.Drawing.Point(272, 381)
-		Me.txtPastebinURL.Name = "txtPastebinURL"
-		Me.txtPastebinURL.ReadOnly = True
-		Me.txtPastebinURL.Size = New System.Drawing.Size(481, 22)
-		Me.txtPastebinURL.TabIndex = 4
-		Me.txtPastebinURL.Visible = False
-		'
-		'lblPastebinURL
-		'
-		Me.lblPastebinURL.AutoSize = True
-		Me.lblPastebinURL.Location = New System.Drawing.Point(195, 386)
-		Me.lblPastebinURL.Name = "lblPastebinURL"
-		Me.lblPastebinURL.Size = New System.Drawing.Size(71, 13)
-		Me.lblPastebinURL.TabIndex = 3
-		Me.lblPastebinURL.Text = "Pastbin URL:"
-		Me.lblPastebinURL.Visible = False
-		'
-		'lblInfo
-		'
-		Me.lblInfo.Location = New System.Drawing.Point(6, 341)
-		Me.lblInfo.Name = "lblInfo"
-		Me.lblInfo.Size = New System.Drawing.Size(858, 13)
-		Me.lblInfo.TabIndex = 5
-		Me.lblInfo.Text = "Before submitting bug reports, please verify that the bug has not already been re" & _
-		  "ported. You can view a listing of all known bugs here:"
-		Me.lblInfo.TextAlign = System.Drawing.ContentAlignment.TopCenter
-		'
-		'llblURL
-		'
-		Me.llblURL.AutoSize = True
-		Me.llblURL.Location = New System.Drawing.Point(296, 354)
-		Me.llblURL.Name = "llblURL"
-		Me.llblURL.Size = New System.Drawing.Size(219, 13)
-		Me.llblURL.TabIndex = 4
-		Me.llblURL.TabStop = True
-		Me.llblURL.Text = "https://sourceforge.net/apps/trac/emm-r/"
-		'
-		'dlgErrorViewer
-		'
-		Me.AcceptButton = Me.OK_Button
-		Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
-		Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
-		Me.CancelButton = Me.OK_Button
-		Me.ClientSize = New System.Drawing.Size(870, 409)
-		Me.Controls.Add(Me.llblURL)
-		Me.Controls.Add(Me.lblInfo)
-		Me.Controls.Add(Me.lblPastebinURL)
-		Me.Controls.Add(Me.txtPastebinURL)
-		Me.Controls.Add(Me.btnCopy)
-		Me.Controls.Add(Me.OK_Button)
-		Me.Controls.Add(Me.txtError)
-		Me.Font = New System.Drawing.Font("Segoe UI", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-		Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog
-		Me.Icon = CType(resources.GetObject("$this.Icon"), System.Drawing.Icon)
-		Me.MaximizeBox = False
-		Me.MinimizeBox = False
-		Me.Name = "dlgErrorViewer"
-		Me.ShowInTaskbar = False
-		Me.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent
-		Me.Text = "Error Log Viewer"
-		Me.ResumeLayout(False)
-		Me.PerformLayout()
+        Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(dlgErrorViewer))
+        Me.OK_Button = New System.Windows.Forms.Button()
+        Me.txtError = New System.Windows.Forms.TextBox()
+        Me.btnCopy = New System.Windows.Forms.Button()
+        Me.txtPastebinURL = New System.Windows.Forms.TextBox()
+        Me.lblPastebinURL = New System.Windows.Forms.Label()
+        Me.lblInfo = New System.Windows.Forms.Label()
+        Me.llblURL = New System.Windows.Forms.LinkLabel()
+        Me.SuspendLayout()
+        '
+        'OK_Button
+        '
+        Me.OK_Button.DialogResult = System.Windows.Forms.DialogResult.Cancel
+        Me.OK_Button.Location = New System.Drawing.Point(797, 381)
+        Me.OK_Button.Name = "OK_Button"
+        Me.OK_Button.Size = New System.Drawing.Size(67, 23)
+        Me.OK_Button.TabIndex = 0
+        Me.OK_Button.Text = "OK"
+        '
+        'txtError
+        '
+        Me.txtError.BackColor = System.Drawing.Color.White
+        Me.txtError.Location = New System.Drawing.Point(6, 7)
+        Me.txtError.Multiline = True
+        Me.txtError.Name = "txtError"
+        Me.txtError.ReadOnly = True
+        Me.txtError.ScrollBars = System.Windows.Forms.ScrollBars.Vertical
+        Me.txtError.Size = New System.Drawing.Size(858, 331)
+        Me.txtError.TabIndex = 1
+        '
+        'btnCopy
+        '
+        Me.btnCopy.Location = New System.Drawing.Point(6, 381)
+        Me.btnCopy.Name = "btnCopy"
+        Me.btnCopy.Size = New System.Drawing.Size(150, 23)
+        Me.btnCopy.TabIndex = 2
+        Me.btnCopy.Text = "Copy To Clipboard"
+        Me.btnCopy.UseVisualStyleBackColor = True
+        Me.btnCopy.Visible = False
+        '
+        'txtPastebinURL
+        '
+        Me.txtPastebinURL.BackColor = System.Drawing.Color.White
+        Me.txtPastebinURL.Location = New System.Drawing.Point(272, 381)
+        Me.txtPastebinURL.Name = "txtPastebinURL"
+        Me.txtPastebinURL.ReadOnly = True
+        Me.txtPastebinURL.Size = New System.Drawing.Size(481, 22)
+        Me.txtPastebinURL.TabIndex = 4
+        Me.txtPastebinURL.Visible = False
+        '
+        'lblPastebinURL
+        '
+        Me.lblPastebinURL.AutoSize = True
+        Me.lblPastebinURL.Location = New System.Drawing.Point(195, 386)
+        Me.lblPastebinURL.Name = "lblPastebinURL"
+        Me.lblPastebinURL.Size = New System.Drawing.Size(71, 13)
+        Me.lblPastebinURL.TabIndex = 3
+        Me.lblPastebinURL.Text = "Pastbin URL:"
+        Me.lblPastebinURL.Visible = False
+        '
+        'lblInfo
+        '
+        Me.lblInfo.Location = New System.Drawing.Point(6, 341)
+        Me.lblInfo.Name = "lblInfo"
+        Me.lblInfo.Size = New System.Drawing.Size(858, 13)
+        Me.lblInfo.TabIndex = 5
+        Me.lblInfo.Text = "Before submitting bug reports, please verify that the bug has not already been re" & _
+    "ported. You can view a listing of all known bugs here:"
+        Me.lblInfo.TextAlign = System.Drawing.ContentAlignment.TopCenter
+        '
+        'llblURL
+        '
+        Me.llblURL.AutoSize = True
+        Me.llblURL.Location = New System.Drawing.Point(219, 354)
+        Me.llblURL.Name = "llblURL"
+        Me.llblURL.Size = New System.Drawing.Size(447, 13)
+        Me.llblURL.TabIndex = 4
+        Me.llblURL.TabStop = True
+        Me.llblURL.Text = "http://bugs.embermediamanager.org/thebuggenie/embermediamanager/issues/open"
+        '
+        'dlgErrorViewer
+        '
+        Me.AcceptButton = Me.OK_Button
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
+        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
+        Me.CancelButton = Me.OK_Button
+        Me.ClientSize = New System.Drawing.Size(870, 409)
+        Me.Controls.Add(Me.llblURL)
+        Me.Controls.Add(Me.lblInfo)
+        Me.Controls.Add(Me.lblPastebinURL)
+        Me.Controls.Add(Me.txtPastebinURL)
+        Me.Controls.Add(Me.btnCopy)
+        Me.Controls.Add(Me.OK_Button)
+        Me.Controls.Add(Me.txtError)
+        Me.Font = New System.Drawing.Font("Segoe UI", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog
+        Me.Icon = CType(resources.GetObject("$this.Icon"), System.Drawing.Icon)
+        Me.MaximizeBox = False
+        Me.MinimizeBox = False
+        Me.Name = "dlgErrorViewer"
+        Me.ShowInTaskbar = False
+        Me.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent
+        Me.Text = "Error Log Viewer"
+        Me.ResumeLayout(False)
+        Me.PerformLayout()
 
-	End Sub
+    End Sub
     Friend WithEvents OK_Button As System.Windows.Forms.Button
     Friend WithEvents txtError As System.Windows.Forms.TextBox
     Friend WithEvents btnCopy As System.Windows.Forms.Button

--- a/EmberMediaManager/dlgErrorViewer.resx
+++ b/EmberMediaManager/dlgErrorViewer.resx
@@ -112,12 +112,12 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABAAEAEBAAAAEAGABoAwAAFgAAACgAAAAQAAAAIAAAAAEAGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA

--- a/EmberMediaManager/dlgErrorViewer.vb
+++ b/EmberMediaManager/dlgErrorViewer.vb
@@ -137,11 +137,11 @@ Public Class dlgErrorViewer
 
     Private Sub llblURL_LinkClicked(ByVal sender As System.Object, ByVal e As System.Windows.Forms.LinkLabelLinkClickedEventArgs) Handles llblURL.LinkClicked
         If Master.isWindows Then
-            Process.Start("https://sourceforge.net/apps/trac/emm-r/")
+            Process.Start("http://bugs.embermediamanager.org/thebuggenie/embermediamanager/issues/open")
         Else
             Using Explorer As New Process
                 Explorer.StartInfo.FileName = "xdg-open"
-                Explorer.StartInfo.Arguments = "https://sourceforge.net/apps/trac/emm-r/"
+                Explorer.StartInfo.Arguments = "http://bugs.embermediamanager.org/thebuggenie/embermediamanager/issues/open"
                 Explorer.Start()
             End Using
         End If


### PR DESCRIPTION
This commit changes the path of the "known bugs" hyperlink in dlgErrorViewer to reflect the new bug tracker. http://bugs.embermediamanager.org/

This is also tied to issue 79 in the bug tracker.
