### PR TITLE
Fixed error on post events / copy folder

### DIFF
--- a/EmberMediaManager/EmberMediaManager.vbproj
+++ b/EmberMediaManager/EmberMediaManager.vbproj
@@ -5229,9 +5229,7 @@
     </PreBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
-    <PostBuildEvent>copy "$(ProjectDir)$(PlatformName)\MediaInfo.dll" "$(TargetDir)Bin\MediaInfo.dll" /Y
-copy "$(ProjectDir)$(PlatformName)\ffmpeg.exe" "$(TargetDir)Bin\ffmpeg.exe" /Y
-xcopy "$(ProjectDir)$(PlatformName)\mediainfo-rar" "$(TargetDir)Bin\mediainfo-rar" /E /I /R /Y</PostBuildEvent>
+    <PostBuildEvent>xcopy "$(ProjectDir)$(PlatformName)" "$(TargetDir)Bin" /E /I /R /Y</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Whole folder copied instead of just files. At first build the copy
commands do not work (weird!) at second build they copy the files so I
changed it with an xcopy of the whole folder
